### PR TITLE
fixing devise user registration edit => issue #58

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -14,4 +14,9 @@ class ApplicationController < ActionController::Base
     logger.debug "default_url_options is passed options: #{options.inspect}\n"
     { locale: I18n.locale }
   end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update, keys: [:company_name, :owner_name, :phone, :diamond_price_in_cents])
+  end
+
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,6 +16,23 @@
                 input_html: { autocomplete: "email", class: 'form-text' } %>
             </div>
             <div class="form-group">
+              <%= f.input :password,
+                label_html: { class: "form-label label-small" },
+                input_html: { autocomplete: "new-password", class: 'form-text'  } %>
+            </div>
+            <div class="form-group">
+              <%= f.input :password_confirmation,
+                label_html: { class: "form-label label-small" },
+                input_html: { autocomplete: "new-password",  class: 'form-text' } %>
+            </div>
+            <div class="form-group">
+              <%= f.input :current_password,
+              required: true,
+              label_html: { class: "form-label label-small" },
+              input_html: { autocomplete: "current-password", class: 'form-text' } %>
+              <i class="form-label label-small my-1">(we need your current password to confirm your changes)</i>
+            </div>
+            <div class="form-group">
               <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
                 <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
               <% end %>
@@ -24,7 +41,7 @@
               <%= f.input :company_name,
                 required: true,
                 label_html: { class: "form-label label-small" },
-                input_html: { class: 'form-text'  } %>
+                input_html: { class: 'form-text' } %>
             </div>
             <div class="form-group">
               <%= f.input :owner_name,


### PR DESCRIPTION
##### What this Pull Request do ?

Fixing the edit user bug (issue #58)

**Fix**:
 - Some mandatory Devise config for strong params where missing in `app/controllers/application_controllers.rb`
 - In `app/views/devise/registrations/edit.html.erb`: the default fields (`password`, `password_confirmatio`n and `current_password`) were not present in the form preventing the `save` action for `User#edit`  to pass. 

(note: `current password` is mandatory for Devise#edit action)

##### Close an issue ? 

Close #58 

##### Required migrations ?

[] yes [x] no

##### Add a new gem ?

[] yes [x] no

##### Add a new package ?

[] yes [x] no
