### PR TITLE
fix for user edit bug => Issue #58

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,9 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:account_update, keys: [:company_name, :owner_name, :phone, :diamond_price_in_cents])
+    devise_parameter_sanitizer.permit(
+      :account_update,
+      keys: %i[company_name owner_name phone diamond_price_in_cents]
+    )
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -14,4 +14,11 @@ class ApplicationController < ActionController::Base
     logger.debug "default_url_options is passed options: #{options.inspect}\n"
     { locale: I18n.locale }
   end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update, keys: [:company_name, :owner_name, :phone, :diamond_price_in_cents])
+  end
+
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,6 +16,23 @@
                 input_html: { autocomplete: "email", class: 'form-text' } %>
             </div>
             <div class="form-group">
+              <%= f.input :password,
+                label_html: { class: "form-label label-small" },
+                input_html: { autocomplete: "new-password", class: 'form-text'  } %>
+            </div>
+            <div class="form-group">
+              <%= f.input :password_confirmation,
+                label_html: { class: "form-label label-small" },
+                input_html: { autocomplete: "new-password",  class: 'form-text' } %>
+            </div>
+            <div class="form-group">
+              <%= f.input :current_password,
+              required: true,
+              label_html: { class: "form-label label-small" },
+              input_html: { autocomplete: "current-password", class: 'form-text' } %>
+              <i class="form-label label-small my-1">(we need your current password to confirm your changes)</i>
+            </div>
+            <div class="form-group">
               <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
                 <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
               <% end %>
@@ -24,7 +41,7 @@
               <%= f.input :company_name,
                 required: true,
                 label_html: { class: "form-label label-small" },
-                input_html: { class: 'form-text'  } %>
+                input_html: { class: 'form-text' } %>
             </div>
             <div class="form-group">
               <%= f.input :owner_name,

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,26 +16,23 @@
                 input_html: { autocomplete: "email", class: 'form-text' } %>
             </div>
             <div class="form-group">
-              <%= f.input :password,
+              <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+                <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+              <% end %>
+            </div>
+              <div class="form-group">
+                <%= f.input :password,
                 label_html: { class: "form-label label-small" },
                 input_html: { autocomplete: "new-password", class: 'form-text'  } %>
-            </div>
+                <i class="font-light text-xs label-small text-blueGray-700">
+                  <%=  I18n.t('devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it') %>
+                </i>
+              </div>
+
             <div class="form-group">
               <%= f.input :password_confirmation,
                 label_html: { class: "form-label label-small" },
                 input_html: { autocomplete: "new-password",  class: 'form-text' } %>
-            </div>
-            <div class="form-group">
-              <%= f.input :current_password,
-              required: true,
-              label_html: { class: "form-label label-small" },
-              input_html: { autocomplete: "current-password", class: 'form-text' } %>
-              <i class="form-label label-small my-1">(we need your current password to confirm your changes)</i>
-            </div>
-            <div class="form-group">
-              <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-                <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
-              <% end %>
             </div>
             <div class="form-group">
               <%= f.input :company_name,
@@ -60,6 +57,15 @@
                 required: true,
                 label_html: { class: "form-label label-small" },
                 input_html: { class: 'form-text' } %>
+            </div>
+            <div class="form-group">
+              <%= f.input :current_password,
+              required: true,
+              label_html: { class: "form-label label-small" },
+              input_html: { autocomplete: "current-password", class: 'form-text' } %>
+              <i class="font-light text-xs label-small text-blueGray-700">
+                <%= I18n.t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %>
+              </i>
             </div>
             <div class="form-group">
               <p class="leading-relaxed mt-1 mb-4 text-blueGray-500">

--- a/config/locales/en/devise.en.yml
+++ b/config/locales/en/devise.en.yml
@@ -48,6 +48,9 @@ en:
       update_needs_confirmation: 'You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address.'
       updated: 'Your account has been updated successfully.'
       updated_but_not_signed_in: 'Your account has been updated successfully, but since your password was changed, you need to sign in again.'
+      edit:
+        we_need_your_current_password_to_confirm_your_changes: 'we need your current password to confirm your changes'
+        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
       new:
         sign_up: Sign up
     sessions:

--- a/config/locales/en/devise.en.yml
+++ b/config/locales/en/devise.en.yml
@@ -49,8 +49,8 @@ en:
       updated: 'Your account has been updated successfully.'
       updated_but_not_signed_in: 'Your account has been updated successfully, but since your password was changed, you need to sign in again.'
       edit:
-        we_need_your_current_password_to_confirm_your_changes: 'we need your current password to confirm your changes'
-        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
+        we_need_your_current_password_to_confirm_your_changes: 'We need your current password to confirm your changes'
+        leave_blank_if_you_don_t_want_to_change_it: Leave blank if you don't want to change it
       new:
         sign_up: Sign up
     sessions:

--- a/config/locales/pt-BR/devise.pt-BR.yml
+++ b/config/locales/pt-BR/devise.pt-BR.yml
@@ -95,11 +95,11 @@ pt-BR:
         are_you_sure: Você tem certeza?
         cancel_my_account: Cancelar minha conta
         currently_waiting_confirmation_for_email: 'No momento esperando por: %{email}'
-        leave_blank_if_you_don_t_want_to_change_it: deixe em branco caso não queira alterá-la
+        leave_blank_if_you_don_t_want_to_change_it: Deixe em branco caso não queira alterá-la
         title: Editar %{resource}
         unhappy: Não está contente?
         update: Atualizar
-        we_need_your_current_password_to_confirm_your_changes: precisamos da sua senha atual para confirmar suas mudanças
+        we_need_your_current_password_to_confirm_your_changes: Precisamos da sua senha atual para confirmar suas mudanças
       new:
         sign_up: Inscrever-se
       signed_up: Bem vindo! Você realizou seu registro com sucesso.


### PR DESCRIPTION
##### What this Pull Request do ?

Fixing the edit user bug (issue #58)
Fix:
	•	Some mandatory Devise config for strong params where missing in `app/controllers/application_controllers.rb`
	•	In `app/views/devise/registrations/edit.html.erb`: the default fields (`password`, `password_confirmation` and `current_password`) were not present in the form preventing the save action for `User#edit` to pass.
(note: current password is mandatory for Devise#edit action)

##### Close an issue ? please insert the hash

Close #58 

##### Required migrations ?

[] yes [x] no

##### Add a new gem ?

[] yes [x] no

##### Add a new package ?

[] yes [x] no
